### PR TITLE
create a resource per access-url when harvesting

### DIFF
--- a/ckanext/geocat/tests/fixtures/complete.xml
+++ b/ckanext/geocat/tests/fixtures/complete.xml
@@ -1015,7 +1015,16 @@
               <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
                 <che:PT_FreeURL>
                   <che:URLGroup>
-                    <che:LocalisedURL locale="#DE">http://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de</che:LocalisedURL>
+                    <che:LocalisedURL locale="#DE">http://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de/1</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de/2</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=fr/1</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=fr/2</che:LocalisedURL>
                   </che:URLGroup>
                 </che:PT_FreeURL>
               </gmd:linkage>
@@ -1152,7 +1161,10 @@
               <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
                 <che:PT_FreeURL>
                   <che:URLGroup>
-                    <che:LocalisedURL locale="#DE">http://wmts.geo.admin.ch</che:LocalisedURL>
+                    <che:LocalisedURL locale="#DE">http://wmts.geo.admin.ch/1</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://wmts.geo.admin.ch/2</che:LocalisedURL>
                   </che:URLGroup>
                 </che:PT_FreeURL>
               </gmd:linkage>

--- a/ckanext/geocat/tests/test_distribution_metadata.py
+++ b/ckanext/geocat/tests/test_distribution_metadata.py
@@ -35,7 +35,7 @@ class TestGeocatDcatDistributionMetadata(unittest.TestCase):
         dcat = metadata.GeocatDcatDistributionMetadata()
         distributions = self._load_xml(dcat, 'complete.xml')
 
-        self.assertEquals(4, len(distributions))
+        self.assertEquals(6, len(distributions))
 
         fields = [
             'identifier',


### PR DESCRIPTION
When a harvested resource has multiple access_urls, we create a copy of the resource per access_url and add them to the dataset. The copied resources will only differ in the resource.url.