### PR TITLE
Calculate unix timestamps manaully from the epoch

### DIFF
--- a/ckanext/geocat/metadata.py
+++ b/ckanext/geocat/metadata.py
@@ -132,7 +132,12 @@ class DcatMetadata(object):
                 datetime_value[0:len('YYYY-MM-DD')],
                 '%Y-%m-%d'
             )
-            return int(time.mktime(d.timetuple()))
+            # we have to calculate this manually since the
+            # time library of Python 2.7 does not support
+            # years < 1900, see OGD-751 and the time docs
+            # https://docs.python.org/2.7/library/time.html
+            epoch = datetime(1970, 1, 1)
+            return int((d - epoch).total_seconds())
         except (ValueError, KeyError, TypeError, IndexError):
             raise ValueError("Could not parse datetime")
 

--- a/ckanext/geocat/tests/fixtures/publication_date_before_1900.xml
+++ b/ckanext/geocat/tests/fixtures/publication_date_before_1900.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<che:CHE_MD_Metadata xmlns:che="http://www.geocat.ch/2008/che" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gml="http://www.opengis.net/gml" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" gco:isoType="gmd:MD_Metadata" xsi:schemaLocation="http://www.geocat.ch/2008/che http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd http://www.isotc211.org/2005/srv http://schemas.opengis.net/iso/19139/20060504/srv/srv.xsd">
+  <gmd:identificationInfo xmlns:xalan="http://xml.apache.org/xalan" xmlns:comp="http://www.geocat.ch/2003/05/gateway/GM03Comprehensive">
+    <che:CHE_MD_DataIdentification gco:isoType="gmd:MD_DataIdentification">
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>1891-12-31</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeListValue="revision" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>1891-12-30</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:citation>
+    </che:CHE_MD_DataIdentification>
+  </gmd:identificationInfo>
+</che:CHE_MD_Metadata>

--- a/ckanext/geocat/tests/test_dataset_metadata.py
+++ b/ckanext/geocat/tests/test_dataset_metadata.py
@@ -260,3 +260,17 @@ class TestGeocatDcatDatasetMetadata(unittest.TestCase):
         self.assertEquals(int(time.mktime(r.timetuple())), dataset['modified'])
 
         self.assertNotEquals(dataset['issued'], dataset['modified'])
+
+    def test_date_issued_before_1900(self):
+        dcat = metadata.GeocatDcatDatasetMetadata()
+        dataset = self._load_xml(dcat, 'publication_date_before_1900.xml')
+
+        self.assertEquals(dataset['issued'], -2461622400)
+        issued = datetime.fromtimestamp(dataset['issued'])
+        self.assertEquals(issued.date().isoformat(), '1891-12-30')
+
+        self.assertEquals(dataset['modified'], -2461536000)
+        modified = datetime.fromtimestamp(dataset['modified'])
+        self.assertEquals(modified.date().isoformat(), '1891-12-31')
+
+        self.assertNotEquals(dataset['issued'], dataset['modified'])


### PR DESCRIPTION
This is needed since the Python 2.7 time library does not support years
< 1900 (see https://docs.python.org/2.7/library/time.html)