### PR TITLE
add relations as named value

### DIFF
--- a/ckanext/geocat/harvester.py
+++ b/ckanext/geocat/harvester.py
@@ -188,7 +188,7 @@ class GeocatHarvester(HarvesterBase):
                     )
                     check_dict = {'identifier': identifier}
                     self._find_existing_package(check_dict)
-                    existing_see_alsos.append(identifier)
+                    existing_see_alsos.append({'dataset_identifier': identifier})  # noqa
                 except NotFound:
                     continue
             pkg_dict['see_alsos'] = existing_see_alsos

--- a/ckanext/geocat/tests/fixtures/complete.xml
+++ b/ckanext/geocat/tests/fixtures/complete.xml
@@ -851,6 +851,21 @@
       <gmd:topicCategory>
         <gmd:MD_TopicCategoryCode>environment_EnvironmentalProtection</gmd:MD_TopicCategoryCode>
       </gmd:topicCategory>
+      <gmd:aggregationInfo>
+        <gmd:MD_AggregateInformation>
+           <gmd:aggregateDataSetIdentifier>
+              <gmd:MD_Identifier>
+                 <gmd:code>
+                    <gco:CharacterString>8454f7d9-e3f2-4cc7-be6d-a82196660ccd</gco:CharacterString>
+                 </gmd:code>
+              </gmd:MD_Identifier>
+           </gmd:aggregateDataSetIdentifier>
+           <gmd:associationType>
+              <gmd:DS_AssociationTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#DS_AssociationTypeCode"
+                                          codeListValue="largerWorkCitation"/>
+           </gmd:associationType>
+        </gmd:MD_AggregateInformation>
+     </gmd:aggregationInfo>
       <gmd:extent xmlns:xlink="http://www.w3.org/1999/xlink" xlink:show="embed">
         <gmd:EX_Extent>
           <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">

--- a/ckanext/geocat/tests/test_dataset_metadata.py
+++ b/ckanext/geocat/tests/test_dataset_metadata.py
@@ -191,7 +191,8 @@ class TestGeocatDcatDatasetMetadata(unittest.TestCase):
 
         # see alsos
         self.assertTrue(hasattr(dataset['see_alsos'], '__iter__'))
-        self.assertEquals(0, len(dataset['see_alsos']))
+        self.assertEquals(1, len(dataset['see_alsos']))
+        self.assertEquals('8454f7d9-e3f2-4cc7-be6d-a82196660ccd', dataset['see_alsos'][0])  # noqa
 
     def test_fields_values_de_only(self):
         dcat = metadata.GeocatDcatDatasetMetadata()


### PR DESCRIPTION
Relations were not added properly which then causes index-rebuild to fail, as it expects see_alsos like so:

```
[
  {u'dataset_identifier': u'123@bundesarchiv'},
  {u'dataset_identifier': u'456@bundesarchiv'}
]
```