### PR TITLE
improve mapping to dct:language on dcat:Dataset

### DIFF
--- a/ckanext/geocat/utils/csw_mapping.py
+++ b/ckanext/geocat/utils/csw_mapping.py
@@ -121,6 +121,10 @@ class GeoMetadataMapping(object):
                         rights=rights,
                     )
                     dataset_dict['resources'].append(resource)
+                    dataset_dict['language'].append(
+                        [lang for lang in resource.get('language')
+                         if lang not in dataset_dict['language']]
+                    )
         geocat_services = xpath_utils.xpath_get_geocat_services(node=root_node)
         if geocat_services:
             for geocat_service in geocat_services:


### PR DESCRIPTION
if a distribution has a language it is also added for the dataset
so the dataset language is mapped first from the geocat dataset language
Later it is corrected using the languages that are specified on the distributions