### PR TITLE
reuse resource ids when updating resources

### DIFF
--- a/ckanext/geocat/harvester.py
+++ b/ckanext/geocat/harvester.py
@@ -270,6 +270,7 @@ class GeocatHarvester(HarvesterBase):
                 schema['__junk'] = [ignore]
                 pkg_dict['name'] = pkg_info.name
                 pkg_dict['id'] = pkg_info.package_id
+                search_utils.map_resources_to_ids(pkg_dict, pkg_info)
                 updated_pkg = \
                     tk.get_action('package_update')(context, pkg_dict)
                 harvest_object.current = True

--- a/ckanext/geocat/utils/search_utils.py
+++ b/ckanext/geocat/utils/search_utils.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 import ckan.plugins.toolkit as tk
 from ckan import model
 from ckan.model import Session
+import json
 
 OgdchDatasetInfo = namedtuple('OgdchDatasetInfo',
                               ['name', 'belongs_to_harvester', 'package_id'])
@@ -121,3 +122,26 @@ def get_value_from_object_extra(harvest_object_extras, key):
         if extra.key == key:
             return extra.value
     return None
+
+
+def map_resources_to_ids(pkg_dict, pkg_info):
+    existing_package = \
+        tk.get_action('package_show')({}, {'id': pkg_info.package_id})
+    existing_resources = existing_package.get('resources')
+    existing_resources_mapping = \
+        {r['id']: _get_resource_id_string(r) for r in existing_resources}
+    for resource in pkg_dict.get('resources'):
+        resource_id_dict = _get_resource_id_string(resource)
+        id_to_reuse = [k for k, v in existing_resources_mapping.items()
+                       if v == resource_id_dict]
+        if id_to_reuse:
+            id_to_reuse = id_to_reuse[0]
+            resource['id'] = id_to_reuse
+            del existing_resources_mapping[id_to_reuse]
+
+
+def _get_resource_id_string(resource):
+    resource_id_dict = {'url': resource.get('url'),
+                        'title': resource.get('title'),
+                        'description': resource.get('description')}
+    return json.dumps(resource_id_dict)


### PR DESCRIPTION
when a dataset is updated the current resource ids are retrieved
matching of the harvested sources to the existing resources is attempted
if a match is found the resource id of the existing resource is
given again to the harvested resource.