### PR TITLE
adapt geocat harvester to implementation change of dct:publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,4 @@ https://geonetwork-opensource.org/manuals/2.10.4/eng/developer/xml_services/csw_
 <harvest-source-url>?service=CSW&version=2.0.2&request=GetRecords
 <harvest-source-url>?service=CSW&version=2.0.2&request=GetRecordById&id=<geocat-id>&elementsetname=full&outputSchema=http://www.isotc211.org/2005/gmd
 ``` 
+

--- a/ckanext/geocat/tests/test_dataset_metadata.py
+++ b/ckanext/geocat/tests/test_dataset_metadata.py
@@ -47,7 +47,7 @@ class TestGeocatDcatDatasetMetadata(unittest.TestCase):
             'description',
             'issued',
             'modified',
-            'publishers',
+            'publisher',
             'contact_points',
             'groups',
             'language',
@@ -64,7 +64,7 @@ class TestGeocatDcatDatasetMetadata(unittest.TestCase):
         ]
 
         for field in fields:
-	    self.assertIn(field, dataset)
+            self.assertIn(field, dataset)
 
         # make sure only the defined fields are on the dataset
         self.assertEquals(sorted(fields), sorted(dataset.keys()))
@@ -103,10 +103,9 @@ class TestGeocatDcatDatasetMetadata(unittest.TestCase):
         self.assertEquals(int(time.mktime(d.timetuple())), dataset['modified'])
 
         # publishers
-        self.assertTrue(hasattr(dataset['publishers'], '__iter__'))
-        self.assertEquals(1, len(dataset['publishers']))
-        for publisher in dataset['publishers']:
-            self.assertEquals(u'Bundesamt f\xfcr Umwelt', publisher['label'])
+        self.assertTrue(isinstance( dataset['publisher'], dict))
+        self.assertEquals(u'Bundesamt f\xfcr Umwelt', publisher['name'])
+        self.assertEquals(u'http://organization/swisstopo', publisher['url'])
 
         # contact points
         self.assertTrue(hasattr(dataset['contact_points'], '__iter__'))

--- a/ckanext/geocat/tests/test_dataset_metadata.py
+++ b/ckanext/geocat/tests/test_dataset_metadata.py
@@ -2,6 +2,7 @@
 from ckanext.geocat.utils import csw_mapping
 from nose.tools import *  # noqa
 import os
+import json
 from datetime import datetime
 import time
 import unittest

--- a/ckanext/geocat/tests/test_dataset_metadata.py
+++ b/ckanext/geocat/tests/test_dataset_metadata.py
@@ -107,7 +107,7 @@ class TestGeocatDcatDatasetMetadata(unittest.TestCase):
         publisher = json.loads(dataset['publisher'])
         self.assertTrue(isinstance(publisher, dict))
         self.assertEquals(u'Bundesamt f\xfcr Umwelt', publisher['name'])
-        self.assertEquals(u'https://organization/swisstopo', publisher['url'])
+        self.assertEquals(u'https://opendata.swiss/organization/swisstopo', publisher['url'])
 
         # contact points
         self.assertTrue(hasattr(dataset['contact_points'], '__iter__'))

--- a/ckanext/geocat/tests/test_dataset_metadata.py
+++ b/ckanext/geocat/tests/test_dataset_metadata.py
@@ -102,8 +102,9 @@ class TestGeocatDcatDatasetMetadata(unittest.TestCase):
         self.assertEquals(int(time.mktime(d.timetuple())), dataset['issued'])
         self.assertEquals(int(time.mktime(d.timetuple())), dataset['modified'])
 
-        # publishers
-        self.assertTrue(isinstance( dataset['publisher'], dict))
+        # publisher
+        publisher = json.loads(dataset['publisher'])
+        self.assertTrue(isinstance(publisher, dict))
         self.assertEquals(u'Bundesamt f\xfcr Umwelt', publisher['name'])
         self.assertEquals(u'http://organization/swisstopo', publisher['url'])
 

--- a/ckanext/geocat/tests/test_dataset_metadata.py
+++ b/ckanext/geocat/tests/test_dataset_metadata.py
@@ -107,7 +107,7 @@ class TestGeocatDcatDatasetMetadata(unittest.TestCase):
         publisher = json.loads(dataset['publisher'])
         self.assertTrue(isinstance(publisher, dict))
         self.assertEquals(u'Bundesamt f\xfcr Umwelt', publisher['name'])
-        self.assertEquals(u'http://organization/swisstopo', publisher['url'])
+        self.assertEquals(u'https://organization/swisstopo', publisher['url'])
 
         # contact points
         self.assertTrue(hasattr(dataset['contact_points'], '__iter__'))

--- a/ckanext/geocat/utils/csw_mapping.py
+++ b/ckanext/geocat/utils/csw_mapping.py
@@ -76,7 +76,7 @@ GMD_KEYWORDS = '//gmd:identificationInfo//gmd:descriptiveKeywords//gmd:keyword' 
 GMD_THEME = '//gmd:identificationInfo//gmd:topicCategory/gmd:MD_TopicCategoryCode/text()'  # noqa
 GMD_ACCRUAL_PERIODICITY = '//gmd:identificationInfo//che:CHE_MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency/gmd:MD_MaintenanceFrequencyCode/@codeListValue'  # noqa
 
-EMPTY_PUBLISHER = [{'label': ''}]
+EMPTY_PUBLISHER = {'url': '', 'name': ''}
 
 
 class GeoMetadataMapping(object):
@@ -106,7 +106,7 @@ class GeoMetadataMapping(object):
                 organization_slug=self.organization_slug)
         dataset_dict['title'] = _map_dataset_title(node=root_node)
         dataset_dict['description'] = _map_dataset_description(node=root_node)
-        dataset_dict['publishers'] = _map_dataset_publisher(node=root_node)
+        dataset_dict['publisher'] = _map_dataset_publisher(node=root_node)
         dataset_dict['contact_points'] = \
             _map_dataset_contact_points(node=root_node)
         dataset_dict['issued'] = _map_dataset_issued(node=root_node)
@@ -233,7 +233,7 @@ def _map_dataset_publisher(node):
         geocat_publisher = \
             xpath_utils.xpath_get_one_value_from_geocat_multilanguage_node(publisher_node)  # noqa
         if geocat_publisher:
-            return ogdch_map_utils.map_to_ogdch_publishers(geocat_publisher)
+            return ogdch_map_utils.map_to_ogdch_publishers(geocat_publisher, self.organization_slug)
     return EMPTY_PUBLISHER
 
 

--- a/ckanext/geocat/utils/csw_mapping.py
+++ b/ckanext/geocat/utils/csw_mapping.py
@@ -106,7 +106,9 @@ class GeoMetadataMapping(object):
                 organization_slug=self.organization_slug)
         dataset_dict['title'] = _map_dataset_title(node=root_node)
         dataset_dict['description'] = _map_dataset_description(node=root_node)
-        dataset_dict['publisher'] = _map_dataset_publisher(node=root_node)
+        dataset_dict['publisher'] = _map_dataset_publisher(
+            node=root_node,
+            organization_slug=self.organization_slug)
         dataset_dict['contact_points'] = \
             _map_dataset_contact_points(node=root_node)
         dataset_dict['issued'] = _map_dataset_issued(node=root_node)
@@ -223,7 +225,7 @@ def _map_dataset_description(node):
     return {'en': '', 'it': '', 'de': '', 'fr': ''}
 
 
-def _map_dataset_publisher(node):
+def _map_dataset_publisher(node, organization_slug):
     publisher_node = \
         xpath_utils.xpath_get_first_of_values_from_path_list(
             node=node,
@@ -233,7 +235,7 @@ def _map_dataset_publisher(node):
         geocat_publisher = \
             xpath_utils.xpath_get_one_value_from_geocat_multilanguage_node(publisher_node)  # noqa
         if geocat_publisher:
-            return ogdch_map_utils.map_to_ogdch_publishers(geocat_publisher, self.organization_slug)
+            return ogdch_map_utils.map_to_ogdch_publishers(geocat_publisher, organization_slug)
     return EMPTY_PUBLISHER
 
 

--- a/ckanext/geocat/utils/csw_mapping.py
+++ b/ckanext/geocat/utils/csw_mapping.py
@@ -235,7 +235,8 @@ def _map_dataset_publisher(node, organization_slug):
         geocat_publisher = \
             xpath_utils.xpath_get_one_value_from_geocat_multilanguage_node(publisher_node)  # noqa
         if geocat_publisher:
-            return ogdch_map_utils.map_to_ogdch_publishers(geocat_publisher, organization_slug)
+            return ogdch_map_utils.map_to_ogdch_publishers(geocat_publisher,
+                                                           organization_slug)
     return EMPTY_PUBLISHER
 
 

--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import json
 from datetime import datetime
 from ckan.lib.munge import munge_tag
 from ckanext.geocat.utils import xpath_utils  # noqa
@@ -22,7 +23,7 @@ def map_to_ogdch_publishers(geocat_publisher, organization_slug):
         'name': geocat_publisher[0],
         'url': _get_organization_url(organization_slug)
     }
-    return dataset_publisher
+    return json.dumps(dataset_publisher)
 
 
 def map_to_ogdch_datetime(datetime_value):

--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -4,16 +4,25 @@ from datetime import datetime
 from ckan.lib.munge import munge_tag
 from ckanext.geocat.utils import xpath_utils  # noqa
 
+ORGANIZATION_URI_BASE = 'https://opendata.swiss/organization/'
+
+
+def _get_organization_url(organization_name):
+    return ORGANIZATION_URI_BASE + organization_name
+
 
 def map_geocat_to_ogdch_identifier(geocat_identifier, organization_slug):
     return '@'.join([geocat_identifier, organization_slug])
 
 
-def map_to_ogdch_publishers(geocat_publisher):
-    dataset_publishers = []
-    for publisher in geocat_publisher:
-        dataset_publishers.append({'label': publisher})
-    return dataset_publishers
+def map_to_ogdch_publishers(geocat_publisher, organization_slug):
+    if not geocat_publisher:
+        return
+    dataset_publisher = {
+        'name': geocat_publisher[0],
+        'url': _get_organization_url(organization_slug)
+    }
+    return dataset_publisher
 
 
 def map_to_ogdch_datetime(datetime_value):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-OWSLib==0.9.2
+OWSLib==0.18.0
 lxml>=4.6.2
 rdflib==4.2.1


### PR DESCRIPTION
publisher is now implemented as a dict ``{'url': ..., 'name': ...}``
as url the url to the organization on opendata,swiss is used.