### PR TITLE
Change urls in the frequency_mapping to the EU frequency values

### DIFF
--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -89,16 +89,16 @@ def map_to_ogdch_categories(geocat_categories):
 
 def map_frequency(geocat_frequency):
     frequency_mapping = {
-        'continual': 'http://purl.org/cld/freq/continuous',
-        'daily': 'http://purl.org/cld/freq/daily',
-        'weekly': 'http://purl.org/cld/freq/weekly',
-        'fortnightly': 'http://purl.org/cld/freq/biweekly',
-        'monthly': 'http://purl.org/cld/freq/monthly',
-        'quarterly': 'http://purl.org/cld/freq/quarterly',
-        'biannually': 'http://purl.org/cld/freq/semiannual',
-        'annually': 'http://purl.org/cld/freq/annual',
-        'asNeeded': 'http://purl.org/cld/freq/irregular',
-        'irregular': 'http://purl.org/cld/freq/irregular',
+        'continual': 'http://publications.europa.eu/resource/authority/frequency/CONT',
+        'daily': 'http://publications.europa.eu/resource/authority/frequency/DAILY',
+        'weekly': 'http://publications.europa.eu/resource/authority/frequency/WEEKLY',
+        'fortnightly': 'http://publications.europa.eu/resource/authority/frequency/BIWEEKLY',
+        'monthly': 'http://publications.europa.eu/resource/authority/frequency/MONTHLY',
+        'quarterly': 'http://publications.europa.eu/resource/authority/frequency/QUARTERLY',
+        'biannually': 'http://publications.europa.eu/resource/authority/frequency/ANNUAL_2',
+        'annually': 'http://publications.europa.eu/resource/authority/frequency/ANNUAL',
+        'asNeeded': 'http://publications.europa.eu/resource/authority/frequency/IRREG',
+        'irregular': 'http://publications.europa.eu/resource/authority/frequency/IRREG',
     }
     return frequency_mapping.get(geocat_frequency, '')
 

--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -89,16 +89,26 @@ def map_to_ogdch_categories(geocat_categories):
 
 def map_frequency(geocat_frequency):
     frequency_mapping = {
-        'continual': 'http://publications.europa.eu/resource/authority/frequency/CONT',
-        'daily': 'http://publications.europa.eu/resource/authority/frequency/DAILY',
-        'weekly': 'http://publications.europa.eu/resource/authority/frequency/WEEKLY',
-        'fortnightly': 'http://publications.europa.eu/resource/authority/frequency/BIWEEKLY',
-        'monthly': 'http://publications.europa.eu/resource/authority/frequency/MONTHLY',
-        'quarterly': 'http://publications.europa.eu/resource/authority/frequency/QUARTERLY',
-        'biannually': 'http://publications.europa.eu/resource/authority/frequency/ANNUAL_2',
-        'annually': 'http://publications.europa.eu/resource/authority/frequency/ANNUAL',
-        'asNeeded': 'http://publications.europa.eu/resource/authority/frequency/IRREG',
-        'irregular': 'http://publications.europa.eu/resource/authority/frequency/IRREG',
+        'continual':
+            'http://publications.europa.eu/resource/authority/frequency/CONT',
+        'daily':
+            'http://publications.europa.eu/resource/authority/frequency/DAILY',
+        'weekly':
+            'http://publications.europa.eu/resource/authority/frequency/WEEKLY',
+        'fortnightly':
+            'http://publications.europa.eu/resource/authority/frequency/BIWEEKLY',
+        'monthly':
+            'http://publications.europa.eu/resource/authority/frequency/MONTHLY',
+        'quarterly':
+            'http://publications.europa.eu/resource/authority/frequency/QUARTERLY',
+        'biannually':
+            'http://publications.europa.eu/resource/authority/frequency/ANNUAL_2',
+        'annually':
+            'http://publications.europa.eu/resource/authority/frequency/ANNUAL',
+        'asNeeded':
+            'http://publications.europa.eu/resource/authority/frequency/IRREG',
+        'irregular':
+            'http://publications.europa.eu/resource/authority/frequency/IRREG',
     }
     return frequency_mapping.get(geocat_frequency, '')
 

--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -90,25 +90,25 @@ def map_to_ogdch_categories(geocat_categories):
 def map_frequency(geocat_frequency):
     frequency_mapping = {
         'continual':
-            'http://publications.europa.eu/resource/authority/frequency/CONT',
+        'http://publications.europa.eu/resource/authority/frequency/CONT',
         'daily':
-            'http://publications.europa.eu/resource/authority/frequency/DAILY',
+        'http://publications.europa.eu/resource/authority/frequency/DAILY',
         'weekly':
-            'http://publications.europa.eu/resource/authority/frequency/WEEKLY',
+        'http://publications.europa.eu/resource/authority/frequency/WEEKLY',
         'fortnightly':
-            'http://publications.europa.eu/resource/authority/frequency/BIWEEKLY',
+        'http://publications.europa.eu/resource/authority/frequency/BIWEEKLY',
         'monthly':
-            'http://publications.europa.eu/resource/authority/frequency/MONTHLY',
+        'http://publications.europa.eu/resource/authority/frequency/MONTHLY',
         'quarterly':
-            'http://publications.europa.eu/resource/authority/frequency/QUARTERLY',
+        'http://publications.europa.eu/resource/authority/frequency/QUARTERLY',
         'biannually':
-            'http://publications.europa.eu/resource/authority/frequency/ANNUAL_2',
+        'http://publications.europa.eu/resource/authority/frequency/ANNUAL_2',
         'annually':
-            'http://publications.europa.eu/resource/authority/frequency/ANNUAL',
+        'http://publications.europa.eu/resource/authority/frequency/ANNUAL',
         'asNeeded':
-            'http://publications.europa.eu/resource/authority/frequency/IRREG',
+        'http://publications.europa.eu/resource/authority/frequency/IRREG',
         'irregular':
-            'http://publications.europa.eu/resource/authority/frequency/IRREG',
+        'http://publications.europa.eu/resource/authority/frequency/IRREG',
     }
     return frequency_mapping.get(geocat_frequency, '')
 


### PR DESCRIPTION
Store EU frequency uris and values (http://publications.europa.eu/resource/authority/frequency)
instead of URLS of the DCAT vocabulary: http://purl.org/cld/freq