### PR TITLE
feat: map publisher url from geocat along with the publisher url

### DIFF
--- a/ckanext/geocat/tests/test_dataset_metadata.py
+++ b/ckanext/geocat/tests/test_dataset_metadata.py
@@ -107,7 +107,7 @@ class TestGeocatDcatDatasetMetadata(unittest.TestCase):
         publisher = json.loads(dataset['publisher'])
         self.assertTrue(isinstance(publisher, dict))
         self.assertEquals(u'Bundesamt f\xfcr Umwelt', publisher['name'])
-        self.assertEquals(u'https://opendata.swiss/organization/swisstopo', publisher['url'])
+        self.assertEquals(u'http://www.bafu.admin.ch/abteilung-laerm-nis', publisher['url'])
 
         # contact points
         self.assertTrue(hasattr(dataset['contact_points'], '__iter__'))

--- a/ckanext/geocat/utils/csw_mapping.py
+++ b/ckanext/geocat/utils/csw_mapping.py
@@ -105,7 +105,6 @@ class GeoMetadataMapping(object):
                 node=root_node,
                 organization_slug=self.organization_slug)
         dataset_dict['title'] = _map_dataset_title(node=root_node)
-        log.error(dataset_dict.get('title'))
         dataset_dict['description'] = _map_dataset_description(node=root_node)
         dataset_dict['publisher'] = _map_dataset_publisher(
             node=root_node,

--- a/ckanext/geocat/utils/csw_mapping.py
+++ b/ckanext/geocat/utils/csw_mapping.py
@@ -249,8 +249,10 @@ def _map_dataset_publisher(node, organization_slug):
             path_list=GMD_PUBLISHER,
             get=xpath_utils.XPATH_NODE)
     if publisher_node is not None:
-        publisher = xpath_utils.xpath_get_url_with_label(publisher_node,
-                                                         label_xpath='//gmd:organisationName')
+        publisher = xpath_utils.xpath_get_url_with_label(
+            publisher_node,
+            label_xpath='//gmd:organisationName'
+        )
         geocat_publisher = {
            'name': publisher.get('label'),
            'url': publisher.get('url', organization_slug)

--- a/ckanext/geocat/utils/csw_mapping.py
+++ b/ckanext/geocat/utils/csw_mapping.py
@@ -53,12 +53,12 @@ GMD_LANGUAGE = ['//gmd:identificationInfo//gmd:language/gco:CharacterString/text
                 '//gmd:language/gmd:LanguageCode/@codeListValue']
 GMD_SPATIAL = '//gmd:identificationInfo//gmd:extent//gmd:description/gco:CharacterString/text()'  # noqa
 GMD_PUBLISHER = [
-    '//gmd:identificationInfo//gmd:pointOfContact[.//gmd:CI_RoleCode/@codeListValue = "publisher"]//gmd:organisationName',  # noqa
-    '//gmd:identificationInfo//gmd:pointOfContact[.//gmd:CI_RoleCode/@codeListValue = "owner"]//gmd:organisationName',  # noqa
-    '//gmd:identificationInfo//gmd:pointOfContact[.//gmd:CI_RoleCode/@codeListValue = "pointOfContact"]//gmd:organisationName',  # noqa
-    '//gmd:identificationInfo//gmd:pointOfContact[.//gmd:CI_RoleCode/@codeListValue = "distributor"]//gmd:organisationName',  # noqa
-    '//gmd:identificationInfo//gmd:pointOfContact[.//gmd:CI_RoleCode/@codeListValue = "custodian"]//gmd:organisationName',  # noqa
-    '//gmd:contact//che:CHE_CI_ResponsibleParty//gmd:organisationName',  # noqa
+    '//gmd:identificationInfo//gmd:pointOfContact[.//gmd:CI_RoleCode/@codeListValue = "publisher"]',  # noqa
+    '//gmd:identificationInfo//gmd:pointOfContact[.//gmd:CI_RoleCode/@codeListValue = "owner"]',  # noqa
+    '//gmd:identificationInfo//gmd:pointOfContact[.//gmd:CI_RoleCode/@codeListValue = "pointOfContact"]',  # noqa
+    '//gmd:identificationInfo//gmd:pointOfContact[.//gmd:CI_RoleCode/@codeListValue = "distributor"]',  # noqa
+    '//gmd:identificationInfo//gmd:pointOfContact[.//gmd:CI_RoleCode/@codeListValue = "custodian"]',  # noqa
+    '//gmd:contact//che:CHE_CI_ResponsibleParty',  # noqa
 ]
 GMD_CONTACT_POINT = [
     '//gmd:identificationInfo//gmd:pointOfContact[.//gmd:CI_RoleCode/@codeListValue = "pointOfContact"]//gmd:address//gmd:electronicMailAddress/gco:CharacterString',  # noqa
@@ -105,6 +105,7 @@ class GeoMetadataMapping(object):
                 node=root_node,
                 organization_slug=self.organization_slug)
         dataset_dict['title'] = _map_dataset_title(node=root_node)
+        log.error(dataset_dict.get('title'))
         dataset_dict['description'] = _map_dataset_description(node=root_node)
         dataset_dict['publisher'] = _map_dataset_publisher(
             node=root_node,
@@ -184,7 +185,7 @@ class GeoMetadataMapping(object):
 
         if protocol in ogdch_map_utils.get_landing_page_protocols():
             url_with_label = \
-                xpath_utils.xpath_get_url_with_label_from_distribution(
+                xpath_utils.xpath_get_url_with_label(
                     resource_node)
             if url_with_label:
                 if not dataset_dict.get('url'):
@@ -193,7 +194,7 @@ class GeoMetadataMapping(object):
                     dataset_dict['relations'].append(url_with_label)
         elif protocol in ogdch_map_utils.get_additonal_relation_protocols():
             url_with_label = \
-                xpath_utils.xpath_get_url_with_label_from_distribution(
+                xpath_utils.xpath_get_url_with_label(
                     resource_node)
             if url_with_label:
                 dataset_dict['relations'].append(url_with_label)
@@ -248,11 +249,13 @@ def _map_dataset_publisher(node, organization_slug):
             path_list=GMD_PUBLISHER,
             get=xpath_utils.XPATH_NODE)
     if publisher_node is not None:
-        geocat_publisher = \
-            xpath_utils.xpath_get_one_value_from_geocat_multilanguage_node(publisher_node)  # noqa
-        if geocat_publisher:
-            return ogdch_map_utils.map_to_ogdch_publisher(geocat_publisher,
-                                                          organization_slug)
+        publisher = xpath_utils.xpath_get_url_with_label(publisher_node,
+                                                         label_xpath='//gmd:organisationName')
+        geocat_publisher = {
+           'name': publisher.get('label'),
+           'url': publisher.get('url', organization_slug)
+        }
+        return ogdch_map_utils. map_to_ogdch_publisher(geocat_publisher)
     return EMPTY_PUBLISHER
 
 

--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -16,14 +16,10 @@ def map_geocat_to_ogdch_identifier(geocat_identifier, organization_slug):
     return '@'.join([geocat_identifier, organization_slug])
 
 
-def map_to_ogdch_publisher(geocat_publisher, organization_slug):
+def map_to_ogdch_publisher(geocat_publisher):
     if not geocat_publisher:
         return
-    dataset_publisher = {
-        'name': geocat_publisher[0],
-        'url': _get_organization_url(organization_slug)
-    }
-    return json.dumps(dataset_publisher)
+    return json.dumps(geocat_publisher)
 
 
 def map_to_ogdch_datetime(datetime_value):

--- a/ckanext/geocat/utils/xpath_utils.py
+++ b/ckanext/geocat/utils/xpath_utils.py
@@ -173,7 +173,7 @@ def xpath_get_one_value_from_geocat_multilanguage_node(node):
             return value_locale
 
 
-def xpath_get_url_with_label_from_distribution(node):
+def xpath_get_url_with_label(node, label_xpath='.//gmd:description'):
     url_node = node.xpath('.//gmd:linkage/gmd:URL/text()',
                           namespaces=gmd_namespaces)
     if not url_node:
@@ -191,7 +191,7 @@ def xpath_get_url_with_label_from_distribution(node):
 
     url = {'url': url_node[0], 'label': url_node[0]}
 
-    text_node = node.xpath('.//gmd:description',
+    text_node = node.xpath(label_xpath,
                            namespaces=gmd_namespaces)
     if text_node:
         url_text_node = \


### PR DESCRIPTION
if the xml-node for the contact that is mapped as publisher
has a url, that that url is taken as the publisher url. If a
publisher url cannot be found the organization slug on opendata.swiss
is still used as fallback to construct the publisher url