### PR TITLE
fix: pickup of mulitilingual fields fallback in geocat source

### DIFF
--- a/ckanext/geocat/utils/xpath_utils.py
+++ b/ckanext/geocat/utils/xpath_utils.py
@@ -113,21 +113,23 @@ def xpath_get_first_of_values_from_path_list(node, path_list, get=XPATH_NODE):
 
 def xpath_get_language_dict_from_geocat_multilanguage_node(node):
     language_dict = {'en': '', 'it': '', 'de': '', 'fr': ''}
-    try:
-        for locale in LOCALES:
-            value_locale = \
-                node.xpath('.//gmd:textGroup/gmd:LocalisedCharacterString[@locale="#{}"]'  # noqa
-                           .format(locale) + '/text()',
-                           namespaces=gmd_namespaces)
-            if value_locale:
-                language_dict[locale.lower()] = _clean_string(value_locale[0])
+    one_locale_found = False
+    for locale in LOCALES:
+        value_locale = \
+            node.xpath('.//gmd:textGroup/gmd:LocalisedCharacterString[@locale="#{}"]'  # noqa
+                       .format(locale) + '/text()',
+                       namespaces=gmd_namespaces)
+        if value_locale:
+            one_locale_found = True
+            language_dict[locale.lower()] = _clean_string(value_locale[0])
+    if one_locale_found:
         return language_dict
-    except:
-        value = node.xpath('.//gco:CharacterString/text()',
-                           namespaces=gmd_namespaces)
-        if value:
-            for locale in LOCALES:
-                language_dict[locale] = value
+    value = node.xpath('.//gco:CharacterString/text()',
+                       namespaces=gmd_namespaces)
+    if value:
+        for locale in LOCALES:
+            language_dict[locale.lower()] = value[0]
+        return language_dict
     return language_dict
 
 


### PR DESCRIPTION
for the multilingual dataset properties title and description:

- it is attempted to find localized strings
- when no localized string is found the non localized string is used
- otherwise the language dictionary is returned with empty strings

this assignement had and error and failed to return the fallback
correctly