### PR TITLE
fix: resource title

### DIFF
--- a/ckanext/geocat/tests/fixtures/geocat-testdata.xml
+++ b/ckanext/geocat/tests/fixtures/geocat-testdata.xml
@@ -11939,15 +11939,6 @@
                                 <gmd:protocol>
                                     <gco:CharacterString>OGC:WMS</gco:CharacterString>
                                 </gmd:protocol>
-                                <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
-                                    <gco:CharacterString>DE#WMS Dienst</gco:CharacterString>
-                                    <gmd:PT_FreeText>
-                                        <gmd:textGroup>
-                                            <gmd:LocalisedCharacterString locale="#DE">DE#WMS Dienst
-                                            </gmd:LocalisedCharacterString>
-                                        </gmd:textGroup>
-                                    </gmd:PT_FreeText>
-                                </gmd:name>
                             </gmd:CI_OnlineResource>
                         </gmd:onLine>
                         <gmd:onLine>
@@ -11990,7 +11981,7 @@
                                     <gco:CharacterString>Map Preview</gco:CharacterString>
                                     <gmd:PT_FreeText>
                                         <gmd:textGroup>
-                                            <gmd:LocalisedCharacterString locale="#DE">Map Preview
+                                            <gmd:LocalisedCharacterString locale="#DE">Kartenvorschau
                                             </gmd:LocalisedCharacterString>
                                         </gmd:textGroup>
                                     </gmd:PT_FreeText>
@@ -11999,7 +11990,7 @@
                                     <gco:CharacterString>map preview</gco:CharacterString>
                                     <gmd:PT_FreeText>
                                         <gmd:textGroup>
-                                            <gmd:LocalisedCharacterString locale="#DE">map preview
+                                            <gmd:LocalisedCharacterString locale="#DE">Kartenvorschau
                                             </gmd:LocalisedCharacterString>
                                         </gmd:textGroup>
                                     </gmd:PT_FreeText>

--- a/ckanext/geocat/tests/test_distribution_metadata.py
+++ b/ckanext/geocat/tests/test_distribution_metadata.py
@@ -122,13 +122,17 @@ class TestGeocatNormedDistributionProtocols(TestGeocatDistributionProtocols):
         self.assertIsNone(distribution.get('download_url'))
         self.assertEquals('SERVICE', distribution.get('format'))
 
-    def test_normed_protocol_OGC_WMS(self):
+    def test_normed_protocol_OGC_WMS_without_gmd_name(self):
         ogc_wms_protocol = 'OGC:WMS'
         distribution = self._get_distribution_by_protocol(ogc_wms_protocol)
         self.assertIsNotNone(distribution)
         self.assertIsNotNone(distribution.get('url'))
         self.assertIsNone(distribution.get('download_url'))
         self.assertEquals('WMS', distribution.get('format'))
+        self.assertEquals('', distribution['title']['de'])
+        self.assertEquals('', distribution['title']['en'])
+        self.assertEquals('', distribution['title']['fr'])
+        self.assertEquals('', distribution['title']['it'])
 
     def test_normed_protocol_Map_Preview(self):
         map_preview_protocol = 'MAP:Preview'
@@ -140,6 +144,10 @@ class TestGeocatNormedDistributionProtocols(TestGeocatDistributionProtocols):
         self.assertIsNotNone(distribution.get('url'))
         self.assertIsNone(distribution.get('download_url'))
         self.assertEquals('SERVICE', distribution.get('format'))
+        self.assertEquals('Map (Preview) Kartenvorschau', distribution['title']['de'])
+        self.assertEquals('Map (Preview)', distribution['title']['en'])
+        self.assertEquals('Map (Preview)', distribution['title']['fr'])
+        self.assertEquals('Map (Preview)', distribution['title']['it'])
 
     def test_normed_protocol_ESRI_REST(self):
         esri_rest_protocol = 'ESRI:REST'
@@ -149,6 +157,9 @@ class TestGeocatNormedDistributionProtocols(TestGeocatDistributionProtocols):
         self.assertIsNone(distribution.get('download_url'))
         self.assertEquals('API', distribution.get('format'))
         self.assertEquals('RESTful API von geo.admin.ch', distribution['title']['de'])
+        self.assertEquals('', distribution['title']['en'])
+        self.assertEquals('', distribution['title']['fr'])
+        self.assertEquals('', distribution['title']['it'])
 
     def test_normed_protocol_WWW_DOWNLOAD_with_format_INTERLIS(self):
         download_protocol_with_format = "WWW:DOWNLOAD:INTERLIS"

--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -244,11 +244,11 @@ def _map_geocat_resource_name_to_title(normed_protocol, name):
     """
     if name and normed_protocol == xpath_utils.MAP_PROTOCOL:
         return {
-            'de': MAP_PROTOCOL_PREFIX + " " + name['de'],
-            'fr': MAP_PROTOCOL_PREFIX + " " + name['fr'],
-            'en': MAP_PROTOCOL_PREFIX + " " + _remove_duplicate_term_in_name(
-                name['en'], "Preview"),
-            'it': MAP_PROTOCOL_PREFIX + " " + name['it'],
+            'de': (MAP_PROTOCOL_PREFIX + " " + name['de']).strip(),
+            'fr': (MAP_PROTOCOL_PREFIX + " " + name['fr']).strip(),
+            'en': (MAP_PROTOCOL_PREFIX + " " + _remove_duplicate_term_in_name(
+                name['en'], "Preview")).strip(),
+            'it': (MAP_PROTOCOL_PREFIX + " " + name['it']).strip(),
         }
     return name
 

--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -214,10 +214,9 @@ def map_resource(geocat_resource, issued, modified, rights):
     if geocat_resource.get('format'):
         resource_dict['format'] = geocat_resource['format']
     resource_dict['description'] = geocat_resource.get('description')
-    resource_dict['title'] = _get_resource_title(
+    resource_dict['title'] = _map_geocat_resource_name_to_title(
         normed_protocol=geocat_resource['normed_protocol'],
         name=geocat_resource.get('name'),
-        title=_avoid_none_as_value(geocat_resource.get('title'))
     )
     resource_dict['url'] = _avoid_none_as_value(geocat_resource.get('url'))
     if geocat_resource['normed_protocol'] == xpath_utils.DOWNLOAD_PROTOCOL:
@@ -234,20 +233,14 @@ def _avoid_none_as_value(value):
     return value
 
 
-def _get_resource_title(normed_protocol, name, title):
+def _map_geocat_resource_name_to_title(normed_protocol, name):
     """
-    the name of the resource depends on the normed protocol,
-    the name, that is a multiligual dictionary and the title that
-    is a single value field.
-
     Only Mpa Preview Resources are prefixed with a protocol
     identifier, so that these resources can be identified by the
     frontend.
 
-    In all other cases the name of the geocat reosurce is taken as
-    resource title. Only it the name is not filled the simple
-    geocat title (not a multiligual dictionary) is taken as a
-    fallback value
+    In all other cases the name of the geocat ressurce name is taken as
+    resource title.
     """
     if name and normed_protocol == xpath_utils.MAP_PROTOCOL:
         return {
@@ -257,19 +250,7 @@ def _get_resource_title(normed_protocol, name, title):
                 name['en'], "Preview"),
             'it': MAP_PROTOCOL_PREFIX + " " + name['it'],
         }
-    if not name:
-        return {
-            'de': title,
-            'fr': title,
-            'en': title,
-            'it': title,
-        }
-    return {
-        'de': name['de'],
-        'fr': name['fr'],
-        'en': name['en'],
-        'it': name['it'],
-    }
+    return name
 
 
 def _remove_duplicate_term_in_name(name, term):

--- a/ckanext/geocat/utils/xpath_utils.py
+++ b/ckanext/geocat/utils/xpath_utils.py
@@ -53,7 +53,7 @@ URL_PATH_LIST = [
     './/che:LocalisedURL/text()',
     './/gmd:URL/text()',
 ]
-GMD_RESOURCE_NAME = './/gmd:name/gco:CharacterString/text()'
+GMD_RESOURCE_NAME = './/gmd:name'
 GMD_RESOURCE_DESCRIPTION = './/gmd:description'
 
 DOWNLOAD_PROTOCOL = "WWW:DOWNLOAD"
@@ -252,10 +252,14 @@ def xpath_get_distribution_from_distribution_node(
     """
     distribution = {}
 
-    distribution['name'] = \
-        xpath_get_language_dict_from_geocat_multilanguage_node(
-            resource_node)
-
+    name_node = xpath_get_single_sub_node_for_node_and_path(
+        node=resource_node, path=GMD_RESOURCE_NAME)
+    if name_node:
+        distribution['name'] = \
+            xpath_get_language_dict_from_geocat_multilanguage_node(
+                name_node)
+    else:
+        distribution['name'] = {'en': '', 'it': '', 'de': '', 'fr': ''}
     description_node = \
         xpath_get_single_sub_node_for_node_and_path(
             node=resource_node, path=GMD_RESOURCE_DESCRIPTION)
@@ -309,7 +313,7 @@ def xpath_get_geocat_services(node):
     if service_nodes:
         for service_node in service_nodes:
             geocat_service = {}
-            geocat_service['title'] = xpath_get_single_sub_node_for_node_and_path(  # noqa
+            geocat_service['name'] = xpath_get_single_sub_node_for_node_and_path(  # noqa
                 node=service_node, path=GMD_SERVICE_TITLE)
             geocat_service['url'], _ = \
                 xpath_get_first_of_values_from_path_list(

--- a/ckanext/geocat/utils/xpath_utils.py
+++ b/ckanext/geocat/utils/xpath_utils.py
@@ -274,7 +274,33 @@ def xpath_get_distribution_from_distribution_node(
     distribution['protocol'] = protocol
     distribution['normed_protocol'] = normed_protocol
 
-    if normed_protocol == DOWNLOAD_PROTOCOL and protocol.startswith(DOWNLOAD_PROTOCOL + ':'):  # noqa
+    _set_distribution_format_and_media_type(
+        protocol,
+        normed_protocol,
+        distribution
+    )
+
+    GMD_URL = './/gmd:linkage'
+    url_node = \
+        xpath_get_single_sub_node_for_node_and_path(
+            node=resource_node, path=GMD_URL)
+    if url_node is not None:
+        distribution_url, distribution_language = \
+            xpath_get_url_and_languages(url_node)
+        distribution['url'] = _clean_string(distribution_url)
+        distribution['language'] = distribution_language
+    return distribution
+
+
+def _set_distribution_format_and_media_type(
+    protocol,
+    normed_protocol,
+    distribution,
+):
+    protocol_is_download_protocol_and_has_format = \
+        normed_protocol == DOWNLOAD_PROTOCOL and \
+        protocol.startswith(DOWNLOAD_PROTOCOL + ':')
+    if protocol_is_download_protocol_and_has_format:
         format = protocol.replace(DOWNLOAD_PROTOCOL + ':', '')
         if format:
             distribution['media_type'] = format
@@ -292,17 +318,6 @@ def xpath_get_distribution_from_distribution_node(
     elif normed_protocol in FORMATED_SERVICE_PROTOCOLS:
         format = re.findall(r'(?<=:).*$', normed_protocol)[0]
         distribution['format'] = format
-
-    GMD_URL = './/gmd:linkage'
-    url_node = \
-        xpath_get_single_sub_node_for_node_and_path(
-            node=resource_node, path=GMD_URL)
-    if url_node is not None:
-        distribution_url, distribution_language = \
-            xpath_get_url_and_languages(url_node)
-        distribution['url'] = _clean_string(distribution_url)
-        distribution['language'] = distribution_language
-    return distribution
 
 
 def xpath_get_geocat_services(node):


### PR DESCRIPTION
if the gmd:name is not set for a geocat resource the resource
title should be empty