### PR TITLE
feat: harvester writes custom activities if a dataset has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,4 @@ https://geonetwork-opensource.org/manuals/2.10.4/eng/developer/xml_services/csw_
 <harvest-source-url>?service=CSW&version=2.0.2&request=GetRecords
 <harvest-source-url>?service=CSW&version=2.0.2&request=GetRecordById&id=<geocat-id>&elementsetname=full&outputSchema=http://www.isotc211.org/2005/gmd
 ``` 
+

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -136,6 +136,13 @@ cd ckanext-showcase
 python setup.py develop
 cd -
 
+echo "Installing ckanext-subscribe and its requirements..."
+git clone https://github.com/opendata-swiss/ckanext-subscribe
+cd ckanext-subscribe
+python setup.py develop
+pip install -r requirements.txt
+cd -
+
 echo "Installing ckanext-switzerland and its requirements..."
 git clone https://github.com/opendata-swiss/ckanext-switzerland-ng
 cd ckanext-switzerland-ng

--- a/ckanext/geocat/harvester.py
+++ b/ckanext/geocat/harvester.py
@@ -295,7 +295,10 @@ class GeocatHarvester(HarvesterBase):
                 schema['__junk'] = [ignore]
                 pkg_dict['name'] = pkg_info.name
                 pkg_dict['id'] = pkg_info.package_id
-                existing_package = map_resources_to_ids(pkg_dict, pkg_info.package_id)
+                existing_package = map_resources_to_ids(
+                    pkg_dict,
+                    pkg_info.package_id
+                )
                 if check_package_change(existing_package, pkg_dict):
                     create_activity(package_id=pkg_dict['id'])
                 updated_pkg = \

--- a/ckanext/geocat/harvester.py
+++ b/ckanext/geocat/harvester.py
@@ -14,6 +14,11 @@ import ckan.plugins.toolkit as tk
 from ckan import model
 from ckan.model import Session
 import uuid
+from ckanext.geocat.utils.harvest_helper import (
+    map_resources_to_ids,
+    check_package_change,
+    create_activity,
+)
 
 import logging
 log = logging.getLogger(__name__)
@@ -290,7 +295,9 @@ class GeocatHarvester(HarvesterBase):
                 schema['__junk'] = [ignore]
                 pkg_dict['name'] = pkg_info.name
                 pkg_dict['id'] = pkg_info.package_id
-                search_utils.map_resources_to_ids(pkg_dict, pkg_info)
+                existing_package = map_resources_to_ids(pkg_dict, pkg_info.package_id)
+                if check_package_change(existing_package, pkg_dict):
+                    create_activity(package_id=pkg_dict['id'])
                 updated_pkg = \
                     tk.get_action('package_update')(context, pkg_dict)
                 harvest_object.current = True

--- a/ckanext/geocat/utils/harvest_helper.py
+++ b/ckanext/geocat/utils/harvest_helper.py
@@ -1,0 +1,80 @@
+import ckan.plugins.toolkit as tk
+import ckan.model as model
+from dateutil.parser import parse as dateutil_parse
+import json
+
+import logging
+
+log = logging.getLogger(__name__)
+
+NOTIFICATION_USER = 'admin'
+
+
+def map_resources_to_ids(pkg_dict, package_id):
+    existing_package = \
+        tk.get_action('package_show')({}, {'id': package_id})
+    existing_resources = existing_package.get('resources')
+    existing_resources_mapping = \
+        {r['id']: _get_resource_id_string(r) for r in existing_resources}
+    for resource in pkg_dict.get('resources'):
+        resource_id_dict = _get_resource_id_string(resource)
+        id_to_reuse = [k for k, v in existing_resources_mapping.items()
+                       if v == resource_id_dict]
+        if id_to_reuse:
+            id_to_reuse = id_to_reuse[0]
+            resource['id'] = id_to_reuse
+            del existing_resources_mapping[id_to_reuse]
+    return existing_package
+
+
+def create_activity(package_id):
+    notification_user = tk.get_action('user_show')({}, {'id': NOTIFICATION_USER})
+    activity_dict = {
+        'user_id': notification_user['id'],
+        'object_id': package_id,
+        'activity_type': 'changed package',
+    }
+    activity_create_context = {
+        'model': model,
+        'user': NOTIFICATION_USER,
+        'defer_commit': True,
+        'ignore_auth': True,
+        'session': model.Session
+    }
+    tk.get_action('activity_create')(activity_create_context, activity_dict)
+
+
+def check_package_change(existing_pkg, dataset_dict):
+    if _changes_in_date(existing_pkg['modified'], dataset_dict['modified']):
+        return True
+    if len(existing_pkg.get('resources')) != len(dataset_dict.get('resources')):
+        return True
+    for resource in dataset_dict.get('resources'):
+        matching_existing_resource = [existing_resource for existing_resource in existing_pkg['resources']
+                                      if existing_resource['id'] == resource['id']]
+        if not matching_existing_resource:
+            return True
+        matching_existing_resource = matching_existing_resource[0]
+        if matching_existing_resource.get('url') != resource.get('url'):
+            return True
+        if matching_existing_resource.get('download_url') != resource.get('download_url'):
+            return True
+        if _changes_in_date(matching_existing_resource.get('modified'), resource.get('modified')):
+            return True
+    return False
+
+
+def _get_resource_id_string(resource):
+    return resource.get('url')
+
+
+def _changes_in_date(ogdch_date, isodate_date):
+    if not ogdch_date and not isodate_date:
+        return False
+    if not ogdch_date or not isodate_date:
+        return True
+    datetime_from_ogdch_date = dateutil_parse(ogdch_date, dayfirst=True)
+    datetime_from_isodate_date = dateutil_parse(isodate_date)
+    if datetime_from_ogdch_date.date() == datetime_from_isodate_date.date():
+        return False
+    return True

--- a/ckanext/geocat/utils/search_utils.py
+++ b/ckanext/geocat/utils/search_utils.py
@@ -131,26 +131,3 @@ def get_value_from_object_extra(harvest_object_extras, key):
         if extra.key == key:
             return extra.value
     return None
-
-
-def map_resources_to_ids(pkg_dict, pkg_info):
-    existing_package = \
-        tk.get_action('package_show')({}, {'id': pkg_info.package_id})
-    existing_resources = existing_package.get('resources')
-    existing_resources_mapping = \
-        {r['id']: _get_resource_id_string(r) for r in existing_resources}
-    for resource in pkg_dict.get('resources'):
-        resource_id_dict = _get_resource_id_string(resource)
-        id_to_reuse = [k for k, v in existing_resources_mapping.items()
-                       if v == resource_id_dict]
-        if id_to_reuse:
-            id_to_reuse = id_to_reuse[0]
-            resource['id'] = id_to_reuse
-            del existing_resources_mapping[id_to_reuse]
-
-
-def _get_resource_id_string(resource):
-    resource_id_dict = {'url': resource.get('url'),
-                        'title': resource.get('title'),
-                        'description': resource.get('description')}
-    return json.dumps(resource_id_dict)

--- a/ckanext/geocat/utils/search_utils.py
+++ b/ckanext/geocat/utils/search_utils.py
@@ -2,7 +2,6 @@ from collections import namedtuple
 import ckan.plugins.toolkit as tk
 from ckan import model
 from ckan.model import Session
-import json
 
 import logging
 


### PR DESCRIPTION
this features customizes the check on when a dataset has changed when a change of the dataset is detected the user harvest-notification creates an activity of type 'package changed'.

Use case:
These activities can be used to trigger notifications in ckanext-subscribe rather then the automaitcally generated activities by the user harvest.

Since the activity type is a fixed vocabulary in CKAN 2.8 the filtering needs to be done by the user who creates the activity rather then by the activity type.