### PR TITLE
Map Linked Data from geocat to an appropriate format

### DIFF
--- a/ckanext/geocat/utils/xpath_utils.py
+++ b/ckanext/geocat/utils/xpath_utils.py
@@ -309,9 +309,10 @@ def _set_distribution_format_and_media_type(
             distribution['media_type'] = ""
     elif normed_protocol == DOWNLOAD_PROTOCOL:
         distribution['media_type'] = ""
-    elif normed_protocol in LINKED_DATA_PROTOCOL:
+    elif normed_protocol == LINKED_DATA_PROTOCOL:
         format = re.findall(r'([^:]+$)', protocol)[0]
-        distribution['format'] = format
+        if format != 'DATA':
+            distribution['format'] = format
     elif normed_protocol == ESRI_REST_PROTOCOL:
         distribution['format'] = API_FORMAT
     elif normed_protocol == APP_PROTOCOL:

--- a/ckanext/geocat/utils/xpath_utils.py
+++ b/ckanext/geocat/utils/xpath_utils.py
@@ -309,6 +309,9 @@ def _set_distribution_format_and_media_type(
             distribution['media_type'] = ""
     elif normed_protocol == DOWNLOAD_PROTOCOL:
         distribution['media_type'] = ""
+    elif normed_protocol in LINKED_DATA_PROTOCOL:
+        format = re.findall(r'([^:]+$)', protocol)[0]
+        distribution['format'] = format
     elif normed_protocol == ESRI_REST_PROTOCOL:
         distribution['format'] = API_FORMAT
     elif normed_protocol == APP_PROTOCOL:


### PR DESCRIPTION
For the Normed Protocol: LINKED:DATA, if the Protocol is given as, e.g., LINKED:DATA:RDF
take the Format RDF as a format of  LINKED:DATA instead of SERVICES.

We will understand Protocols if they are corresponds to the standards of DCAT:  https://handbook.opendata.swiss/de/content/glossar/bibliothek/geocat-mapping.html#gmd-distributioninfo-gmd-md-distribution-to-dcat-distribution 

Thus, if the protocol is given this way: "Linked:Data" we will considered it as a SERVICE  