### PR TITLE
feat: Update date comparison method

### DIFF
--- a/ckanext/geocat/tests/test_helpers.py
+++ b/ckanext/geocat/tests/test_helpers.py
@@ -133,9 +133,9 @@ class TestHarvestHelpersUnit(object):
         )
 
     def test_check_package_change_multiple_resources_changed(self):
-        """The number of resources have changed and so have all the urls,
-        download urls and modified dates, but we should only get a message
-        about the first resource that is different.
+        """All the urls, download urls and modified dates of the resources
+        have changed, but we should only get a message about the first
+        resource that is different.
         """
         existing_package = {
             "resources": [

--- a/ckanext/geocat/tests/test_helpers.py
+++ b/ckanext/geocat/tests/test_helpers.py
@@ -1,0 +1,172 @@
+from ckanext.geocat.utils.harvest_helper import check_package_change
+
+
+class TestHarvestHelpersUnit(object):
+    def test_check_package_change_no_change(self):
+        existing_package = {
+            "modified": "2020-01-02T00:00:00",
+            "resources": [
+                {
+                    "url": "http://example.org/resource-1",
+                    "download_url": "http://example.org/resource-1/download",
+                    "modified": "2020-01-02T00:00:00",
+                },
+            ],
+        }
+        dataset_dict = {
+            "modified": "2020-01-02T00:00:00",
+            "resources": [
+                {
+                    "url": "http://example.org/resource-1",
+                    "download_url": "http://example.org/resource-1/download",
+                    "modified": "2020-01-02T00:00:00",
+                },
+            ],
+        }
+
+        assert check_package_change(existing_package, dataset_dict) == (False, None)
+
+    def test_check_package_change_new_modified_time(self):
+        existing_package = {
+            "modified": "2020-01-02T00:00:00",
+        }
+        dataset_dict = {
+            "modified": "2020-01-02T12:00:00",
+        }
+
+        assert check_package_change(existing_package, dataset_dict) == (
+            True,
+            "dataset modified date changed: 2020-01-02T12:00:00"
+        )
+
+    def test_check_package_change_new_resource_modified_time(self):
+        existing_package = {
+            "resources": [
+                {
+                    "modified": "2020-01-02T00:00:00",
+                },
+            ],
+        }
+        dataset_dict = {
+            "resources": [
+                {
+                    "modified": "2020-01-02T12:00:00",
+                },
+            ],
+        }
+
+        assert check_package_change(existing_package, dataset_dict) == (
+            True,
+            "resource modified date changed: 2020-01-02T12:00:00"
+        )
+
+    def test_check_package_change_new_resource_url(self):
+        existing_package = {
+            "resources": [
+                {
+                    "url": "http://example.org/resource-1",
+                },
+            ],
+        }
+        dataset_dict = {
+            "resources": [
+                {
+                    "url": "http://example.org/new/resource-1",
+                },
+            ],
+        }
+
+        assert check_package_change(existing_package, dataset_dict) == (
+            True,
+            "resource access url changed: http://example.org/new/resource-1"
+        )
+
+    def test_check_package_change_new_resource_download_url(self):
+        existing_package = {
+            "resources": [
+                {
+                    "download_url": "http://example.org/resource-1/download",
+                },
+            ],
+        }
+        dataset_dict = {
+            "resources": [
+                {
+                    "download_url": "http://example.org/new/resource-1/download",
+                },
+            ],
+        }
+
+        assert check_package_change(existing_package, dataset_dict) == (
+            True,
+            "resource download url changed: http://example.org/new/resource-1/download"
+        )
+
+    def test_check_package_change_different_resource_count(self):
+        existing_package = {
+            "resources": [
+                {
+                    "url": "http://example.org/resource-1",
+                    "download_url": "http://example.org/resource-1/download",
+                    "modified": "2020-01-02T00:00:00",
+                },
+                {
+                    "url": "http://example.org/resource-2",
+                    "download_url": "http://example.org/resource-2/download",
+                    "modified": "2020-01-02T00:00:00",
+                },
+            ],
+        }
+        dataset_dict = {
+            "resources": [
+                {
+                    "url": "http://example.org/resource-1",
+                    "download_url": "http://example.org/resource-1/download",
+                    "modified": "2020-01-02T00:00:00",
+                },
+            ],
+        }
+
+        assert check_package_change(existing_package, dataset_dict) == (
+            True,
+            "resource count changed: 1"
+        )
+
+    def test_check_package_change_multiple_resources_changed(self):
+        """The number of resources have changed and so have all the urls,
+        download urls and modified dates, but we should only get a message
+        about the first resource that is different.
+        """
+        existing_package = {
+            "resources": [
+                {
+                    "url": "http://example.org/resource-1",
+                    "download_url": "http://example.org/resource-1/download",
+                    "modified": "2020-01-02T00:00:00",
+                },
+                {
+                    "url": "http://example.org/resource-2",
+                    "download_url": "http://example.org/resource-2/download",
+                    "modified": "2020-01-02T00:00:00",
+                },
+            ],
+        }
+        dataset_dict = {
+            "resources": [
+                {
+                    "url": "http://example.org/new/resource-1",
+                    "download_url": "http://example.org/new/resource-1/download",
+                    "modified": "2020-01-02T12:00:00",
+                },
+                {
+                    "url": "http://example.org/new/resource-2",
+                    "download_url": "http://example.org/new/resource-2/download",
+                    "modified": "2020-01-02T12:00:00",
+                },
+            ],
+        }
+
+        assert check_package_change(existing_package, dataset_dict) == (
+            True,
+            "resource access url changed: http://example.org/new/resource-1"
+        )

--- a/ckanext/geocat/utils/harvest_helper.py
+++ b/ckanext/geocat/utils/harvest_helper.py
@@ -89,13 +89,11 @@ def _get_resource_id_string(resource):
     return resource.get('url')
 
 
-def _changes_in_date(ogdch_date, isodate_date):
-    if not ogdch_date and not isodate_date:
+def _changes_in_date(existing_datetime, new_datetime):
+    if not existing_datetime and not new_datetime:
         return False
-    if not ogdch_date or not isodate_date:
+    if not existing_datetime or not new_datetime:
         return True
-    datetime_from_ogdch_date = dateutil_parse(ogdch_date, dayfirst=True)
-    datetime_from_isodate_date = dateutil_parse(isodate_date)
-    if datetime_from_ogdch_date.date() == datetime_from_isodate_date.date():
+    if dateutil_parse(existing_datetime) == dateutil_parse(new_datetime):
         return False
     return True

--- a/ckanext/geocat/utils/harvest_helper.py
+++ b/ckanext/geocat/utils/harvest_helper.py
@@ -1,6 +1,6 @@
 import ckan.plugins.toolkit as tk
 import ckan.model as model
-from dateutil.parser import parse as dateutil_parse
+from dateutil.parser import parse as dateutil_parse, ParserError
 
 import logging
 
@@ -94,6 +94,15 @@ def _changes_in_date(existing_datetime, new_datetime):
         return False
     if not existing_datetime or not new_datetime:
         return True
-    if dateutil_parse(existing_datetime) == dateutil_parse(new_datetime):
+    try:
+        if dateutil_parse(existing_datetime) == dateutil_parse(new_datetime):
+            return False
+    except (ParserError, OverflowError) as e:
+        log.info(
+            "Error when parsing dates {}, {}: {}".format(
+                existing_datetime, new_datetime, e
+            )
+        )
+
         return False
     return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-OWSLib==0.18.0
 lxml>=4.6.2
-rdflib==5.0.0
+OWSLib==0.18.0
+python-dateutil==2.8.1
 pyyaml==5.4
+rdflib==5.0.0


### PR DESCRIPTION
Issued and modified datetimes for existing datasets are no longer returned as dd.mm.yyyy but as isoformat datetimes.

Merge after https://github.com/opendata-swiss/ckanext-switzerland-ng/pull/263.