### PR TITLE
fix: extend geocat format mapping for format without underscore

### DIFF
--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -270,13 +270,12 @@ def map_service(geocat_service, issued, modified, description, rights):
 
 
 def _map_geocat_resource_format_to_valid_format(geocat_format):
-    geocat_format_without_underscore = geocat_format.replace('_', '')
     valid_formats = mu.get_format_values()
     for key, value in valid_formats.items():
-        if geocat_format == key or geocat_format_without_underscore == key:
+        if geocat_format == key or geocat_format == key.replace('_', ' '):
             return value
     valid_media_types = mu.get_iana_media_type_values()
     for key, value in valid_media_types.items():
-        if geocat_format == key or geocat_format_without_underscore == key:
+        if geocat_format == key or  geocat_format == key.replace('_', ' '):
             return value
     return geocat_format

--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -276,6 +276,6 @@ def _map_geocat_resource_format_to_valid_format(geocat_format):
             return value
     valid_media_types = mu.get_iana_media_type_values()
     for key, value in valid_media_types.items():
-        if geocat_format == key or  geocat_format == key.replace('_', ' '):
+        if geocat_format == key or geocat_format == key.replace('_', ' '):
             return value
     return geocat_format

--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -272,10 +272,10 @@ def map_service(geocat_service, issued, modified, description, rights):
 def _map_geocat_resource_format_to_valid_format(geocat_format):
     valid_formats = mu.get_format_values()
     for key, value in valid_formats.items():
-        if geocat_format == key or geocat_format == key.replace('_', ' '):
+        if geocat_format.replace(' ', '_') == key:
             return value
     valid_media_types = mu.get_iana_media_type_values()
     for key, value in valid_media_types.items():
-        if geocat_format == key or geocat_format == key.replace('_', ' '):
+        if geocat_format.replace(' ', '_') == key:
             return value
     return geocat_format

--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -270,12 +270,13 @@ def map_service(geocat_service, issued, modified, description, rights):
 
 
 def _map_geocat_resource_format_to_valid_format(geocat_format):
+    geocat_format_without_underscore = geocat_format.replace('_', '')
     valid_formats = mu.get_format_values()
     for key, value in valid_formats.items():
-        if geocat_format == key:
+        if geocat_format == key or geocat_format_without_underscore == key:
             return value
     valid_media_types = mu.get_iana_media_type_values()
     for key, value in valid_media_types.items():
-        if geocat_format == key:
+        if geocat_format == key or geocat_format_without_underscore == key:
             return value
     return geocat_format


### PR DESCRIPTION
For making the geocat format DCAT AP v2 conformant we extend the mapping, that it also maps geocat formats that are separated with no underscore on the format of the eu aand iana vocabulary