### PR TITLE
Revert "Merge pull request #121 from opendata-swiss/dependabot/pip/py…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ OWSLib==0.18.0
 pyproj==1.9.6
 python-dateutil==2.8.1
 # TODO: Revert to 5.4 once https://github.com/yaml/pyyaml/issues/724 is fixed
-pyyaml==5.4
+pyyaml==5.3.1
 rdflib==5.0.0


### PR DESCRIPTION
…yaml-5.4"

This reverts commit 52b83c2bee7efcadce84eb632a4a4bc66dfb36c5, reversing changes made to ecf50857012aedad699f11034a239c1772ebf3c

The issue https://github.com/yaml/pyyaml/issues/724 has been fixed, but apparently not for Python 2.7 (very understandable!), so we still can't use pyyaml 5.4. :(