### PR TITLE
fix: introduce envvar as workaround for harvesting dataset-relations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
       CKAN_SOLR_URL: http://solr:8983/solr/ckan
       CKAN_REDIS_URL: redis://redis:6379/1
       CKAN_SITE_URL: http://test.ckan.net
+      CKANEXT__GEOCAT__SITE_URL: http://test.ckan.net
       WORKDIR: /__w/ckanext-geocat/ckanext-geocat
       SOLR_CONFIG_DIR: /opt/solr/server/solr/configsets
       SOLR_CONFIG_CKAN_DIR: /opt/solr/server/solr/configsets/ckan/conf

--- a/ckanext/geocat/config_declaration.yaml
+++ b/ckanext/geocat/config_declaration.yaml
@@ -24,9 +24,10 @@ groups:
         description:
         required: false
       - key: ckanext.geocat.site_url
-        default: "https://ckan.opendata.swiss"
+        default: ""
         description:
           CKAN base URL used when building /perma/{identifier} links for
           qualified relations via harvester (workaround for ckan.site_url being used for 
-          performance of the xloader-image in productive environments).
+          performance of the xloader-image in productive environments). 
+          When empty, ckan.site_url is used. 
         required: false

--- a/ckanext/geocat/config_declaration.yaml
+++ b/ckanext/geocat/config_declaration.yaml
@@ -23,3 +23,10 @@ groups:
         default: "https://www.geocat.ch/geonetwork/srv/ger/catalog.search#/metadata/"
         description:
         required: false
+      - key: ckanext.geocat.site_url
+        default: "https://ckan.opendata.swiss"
+        description:
+          CKAN base URL used when building /perma/{identifier} links for
+          qualified relations via harvester (workaround for ckan.site_url being used for 
+          performance of the xloader-image in productive environments).
+        required: false

--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -164,7 +164,7 @@ def get_geocat_permalink(geocat_id, geocat_perma_link, geocat_perma_label):
 
 
 def get_ogdch_permalink(identifier):
-    site_url = tk.config.get("ckan.site_url")
+    site_url = tk.config.get("ckanext.geocat.site_url", "ckan.site_url")
     return f"{site_url}/perma/{identifier}"
 
 

--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -164,7 +164,8 @@ def get_geocat_permalink(geocat_id, geocat_perma_link, geocat_perma_label):
 
 
 def get_ogdch_permalink(identifier):
-    site_url = tk.config.get("ckanext.geocat.site_url", "ckan.site_url")
+    ckan_site_url = tk.config.get("ckan.site_url")
+    site_url = tk.config.get("ckanext.geocat.site_url", ckan_site_url)
     return f"{site_url}/perma/{identifier}"
 
 

--- a/test.ini
+++ b/test.ini
@@ -34,6 +34,7 @@ ckanext.geocat.permalink_title_de = geocat.ch Permalink
 ckanext.geocat.permalink_title_en = geocat.ch permalink
 ckanext.geocat.permalink_title_fr = geocat.ch permalien
 ckanext.geocat.permalink_title_it = geocat.ch link permanente
+ckanext.geocat.site_url = http://test.ckan.net
 
 # ckanext-scheming
 scheming.dataset_schemas = ckanext.switzerland:dcat-ap-switzerland_scheming.json


### PR DESCRIPTION
On productive environments we can not rely on the CKAN_SITE_URL as it can be configured differently for Xloader-Performance