### PR TITLE
fix: CSW pagination starts at 1, not 0

### DIFF
--- a/ckanext/geocat/utils/csw_processor.py
+++ b/ckanext/geocat/utils/csw_processor.py
@@ -83,7 +83,7 @@ class GeocatCswClientBase(object):
         """
         List dataset identifiers via OWSLib ``getrecords2`` (summary records).
         """
-        nextrecord = 0
+        nextrecord = 1
         record_ids = []
         csw_args = {"maxrecords": 50, "startposition": nextrecord}
 


### PR DESCRIPTION
The CSW protocol uses 1-based indexing for startPosition. Initializing nextrecord to 0 caused the server to treat the first request as invalid and return nextRecord=0 (end-of-results signal), breaking out of the pagination loop after the first page (50 records).

Fix: initialize nextrecord to 1 so the first GetRecords request uses startPosition=1, and subsequent pages are fetched correctly.