### PR TITLE
fix: add Map (Preview) prefix to DCAT-AP-CH distributions

### DIFF
--- a/ckanext/geocat/tests/fixtures/landesschwerenetz-dcat-ap-ch.xml
+++ b/ckanext/geocat/tests/fixtures/landesschwerenetz-dcat-ap-ch.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/95879cd4-e93d-4d4d-af57-4ec6731b9c97/formatters/dcat-ap-ch">
+    <dct:identifier>95879cd4-e93d-4d4d-af57-4ec6731b9c97</dct:identifier>
+    <dct:title xml:lang="de">Landesschwerenetz</dct:title>
+    <dct:title xml:lang="fr">Réseau gravimétrique national</dct:title>
+    <dct:title xml:lang="it">Rete gravimetrica nazionale</dct:title>
+    <dct:title xml:lang="en">National Gravity Network</dct:title>
+    <dct:title xml:lang="rm">Rait gravimetrica naziunala</dct:title>
+    <dct:description xml:lang="de">Aktuell verwendete Basisstationen des Landesschwerenetzes. Diese Stationen werden regelmässig neu vermessen und dienen als Referenzpunkte für gravimetrische Projekte.Das Rückgrat des Netzes bilden die absoluten Schweremessungen. Diese werden verdichtet durch relative Schweremessungen auf Fixpunkten der Landesvermessung.</dct:description>
+    <dct:description xml:lang="fr">Stations actuelles du réseau gravimétrique national. Ces stations sont observées régulièrement et servent comme points de référence pour des projets gravimétriques.La base de ce réseau est formée par les stations absolues qui sont densifiées par des mesures relatives sur des points fixes de la mensuration nationale.</dct:description>
+    <dct:description xml:lang="it">Stazioni di base della rete gravimetrica nazionale attualmente utilizzate. Queste stazioni vengono regolarmente sottoposte a nuove misurazioni e fungono da punti di riferimento per i progetti gravimetrici. La base della rete è costituita dalle misurazioni gravimetriche assolute. Queste vengono intensificate attraverso misurazioni gravimetriche relative eseguite su punti fissi della misurazione nazionale.</dct:description>
+    <dct:description xml:lang="en">Current base stations of the national gravity network. These stations are observed regularly and serve as reference Points for gravimetric projects.The backbone of this network is formed by absolute gravity stations. They are densified by relative measurements on Benchmarks of national Survey.</dct:description>
+    <dct:description xml:lang="rm">Staziuns da basa utilisadas actualmain da la rait gravimetrica naziunala. Las coordinatas da questas staziuns vegnan controlladas regularmain da nov e servan sco puncts da referenza per projects gravimetrics. La basa da la rait èn las staziuns absolutas. Quellas vegnan densifitgadas tras mesiraziuns relativas sur puncts fixs da la mesiraziun naziunala.</dct:description>
+    <dct:publisher>
+      <foaf:Agent rdf:about="https://www.cadastre.ch/">
+        <foaf:name xml:lang="de">Bundesamt für Landestopografie swisstopo, Vermessung</foaf:name>
+        <foaf:name xml:lang="en">Federal office of topography swisstopo, survey</foaf:name>
+        <foaf:name xml:lang="fr">Office fédéral de topographie, mensuration</foaf:name>
+        <foaf:name xml:lang="it">Ufficio federale di topografia swisstopo, misurazione</foaf:name>
+        <foaf:name xml:lang="rm">Bundesamt für Landestopografie swisstopo, Vermessung</foaf:name>
+      </foaf:Agent>
+    </dct:publisher>
+    <dcat:contactPoint>
+      <vcard:Organization>
+        <vcard:fn>Bundesamt für Landestopografie swisstopo, Vermessung</vcard:fn>
+        <vcard:hasEmail rdf:resource="mailto:vermessung@swisstopo.ch" />
+      </vcard:Organization>
+    </dcat:contactPoint>
+    <dcat:distribution>
+      <dcat:Distribution>
+        <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.swisstopo.landesschwerenetz" />
+        <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
+        <dct:description xml:lang="de">Vorschau map.geo.admin.ch</dct:description>
+        <dct:description xml:lang="fr">Aperçu map.geo.admin.ch</dct:description>
+        <dct:description xml:lang="it">Previsione map.geo.admin.ch</dct:description>
+        <dct:description xml:lang="en">Preview map.geo.admin.ch</dct:description>
+        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/HTML" />
+        <dcat:mediaType rdf:resource="http://www.iana.org/assignments/media-types/text/html" />
+        <dct:license rdf:resource="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
+        <dct:rights>
+          <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
+        </dct:rights>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-10T00:00:00+00:00</dct:issued>
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ITA" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
+      </dcat:Distribution>
+    </dcat:distribution>
+    <dcat:distribution>
+      <dcat:Distribution>
+        <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
+        <dct:title xml:lang="de">ch.swisstopo.landesschwerenetz</dct:title>
+        <dct:description xml:lang="de">WMS-BGDI Dienst, Layer "Schweregrundnetz"</dct:description>
+        <dct:description xml:lang="fr">Service WMS-IFDG, couche "Réseau de base gravimétrique"</dct:description>
+        <dct:description xml:lang="it">Servizio WMS-IFDG, strato "Rete gravimetrica di base"</dct:description>
+        <dct:description xml:lang="en">WMS-FSDI service, layer "Gravimetric base network"</dct:description>
+        <dct:description xml:lang="rm">WMS-BGDI Dienst, Layer "Schweregrundnetz"</dct:description>
+        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/WMS_SRVC" />
+        <dct:license rdf:resource="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
+        <dct:rights>
+          <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
+        </dct:rights>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-10T00:00:00+00:00</dct:issued>
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ITA" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
+      </dcat:Distribution>
+    </dcat:distribution>
+    <dcat:distribution>
+      <dcat:Distribution>
+        <dcat:accessURL rdf:resource="https://www.swisstopo.admin.ch/de/landesschwerenetz" />
+        <dct:description xml:lang="de">Link zu Zusatzinformationen</dct:description>
+        <dct:description xml:lang="fr">Lien vers des informations additionelles</dct:description>
+        <dct:description xml:lang="en">Link to additional information</dct:description>
+        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/HTML" />
+        <dcat:mediaType rdf:resource="http://www.iana.org/assignments/media-types/text/html" />
+        <dct:license rdf:resource="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
+        <dct:rights>
+          <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
+        </dct:rights>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-10T00:00:00+00:00</dct:issued>
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ITA" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
+      </dcat:Distribution>
+    </dcat:distribution>
+    <dcat:distribution>
+      <dcat:Distribution>
+        <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.swisstopo.landesschwerenetz" />
+        <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
+        <dct:description xml:lang="de">RESTful API von geo.admin.ch</dct:description>
+        <dct:description xml:lang="fr">RESTful API de geo.admin.ch</dct:description>
+        <dct:description xml:lang="it">RESTful API da geo.admin.ch</dct:description>
+        <dct:description xml:lang="en">RESTful API from geo.admin.ch</dct:description>
+        <dct:description xml:lang="rm">RESTful API dad geo.admin.ch</dct:description>
+        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/REST" />
+        <dct:license rdf:resource="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
+        <dct:rights>
+          <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
+        </dct:rights>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-10T00:00:00+00:00</dct:issued>
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ITA" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
+      </dcat:Distribution>
+    </dcat:distribution>
+    <dcat:distribution>
+      <dcat:Distribution>
+        <dcat:accessURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.swisstopo.landesschwerenetz/items/landesschwerenetz" />
+        <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.swisstopo.landesschwerenetz/items/landesschwerenetz" />
+        <dct:title xml:lang="de">Download von data/geo.admin.ch</dct:title>
+        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/HTML" />
+        <dcat:mediaType rdf:resource="http://www.iana.org/assignments/media-types/text/html" />
+        <dct:license rdf:resource="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
+        <dct:rights>
+          <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
+        </dct:rights>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-10T00:00:00+00:00</dct:issued>
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ITA" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG" />
+        <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
+      </dcat:Distribution>
+    </dcat:distribution>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-10T00:00:00+00:00</dct:issued>
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
+    <dcat:landingPage rdf:resource="https://www.swisstopo.admin.ch/de/landesschwerenetz" />
+    <dct:relation>
+      <rdf:Description rdf:about="https://www.geocat.ch/datahub/dataset/95879cd4-e93d-4d4d-af57-4ec6731b9c97">
+        <rdfs:label xml:lang="de">geocat.ch Permalink</rdfs:label>
+        <rdfs:label xml:lang="fr">geocat.ch permalien</rdfs:label>
+        <rdfs:label xml:lang="it">geocat.ch link permanente</rdfs:label>
+        <rdfs:label xml:lang="en">geocat.ch permalink</rdfs:label>
+      </rdf:Description>
+    </dct:relation>
+    <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
+    <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
+    <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ITA" />
+    <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG" />
+    <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
+    <dcat:keyword xml:lang="de">Gravimetrie</dcat:keyword>
+    <dcat:keyword xml:lang="fr">gravimétrie</dcat:keyword>
+    <dcat:keyword xml:lang="it">gravimetria</dcat:keyword>
+    <dcat:keyword xml:lang="en">gravimetry</dcat:keyword>
+    <dcat:keyword xml:lang="de">Geobasisdaten</dcat:keyword>
+    <dcat:keyword xml:lang="fr">géodonnées de base</dcat:keyword>
+    <dcat:keyword xml:lang="it">geodati di base</dcat:keyword>
+    <dcat:keyword xml:lang="en">official geodata</dcat:keyword>
+    <dcat:keyword xml:lang="de">Aufbewahrungs- und Archivierungsplanung AAP - Bund</dcat:keyword>
+    <dcat:keyword xml:lang="fr">Planification de la conservation et de l'archivage AAP - Conféderation</dcat:keyword>
+    <dcat:keyword xml:lang="it">Pianificazione della conservazione e dell’archiviazione AAP - Confederazione</dcat:keyword>
+    <dcat:keyword xml:lang="en">Conservation and archiving planning AAP - Confederation</dcat:keyword>
+    <dcat:keyword xml:lang="de">opendata.swiss</dcat:keyword>
+    <dcat:keyword xml:lang="fr">opendata.swiss</dcat:keyword>
+    <dcat:keyword xml:lang="it">opendata.swiss</dcat:keyword>
+    <dcat:keyword xml:lang="en">opendata.swiss</dcat:keyword>
+    <dcat:keyword xml:lang="rm">opendata.swiss</dcat:keyword>
+    <dcat:keyword xml:lang="de">opendata.swiss</dcat:keyword>
+    <dcat:keyword xml:lang="fr">opendata.swiss</dcat:keyword>
+    <dcat:keyword xml:lang="it">opendata.swiss</dcat:keyword>
+    <dcat:keyword xml:lang="en">opendata.swiss</dcat:keyword>
+    <dcat:keyword xml:lang="rm">opendata.swiss</dcat:keyword>
+    <dcat:keyword xml:lang="de">BGDI Bundesgeodaten-Infrastruktur</dcat:keyword>
+    <dcat:keyword xml:lang="fr">IFDG l’Infrastructure Fédérale de données géographiques</dcat:keyword>
+    <dcat:keyword xml:lang="it">IFDG Infrastruttura federale dei dati geografici</dcat:keyword>
+    <dcat:keyword xml:lang="en">FSDI Federal Spatial Data Infrastructure</dcat:keyword>
+    <dct:spatial>Schweiz (mit grenznahem Ausland)</dct:spatial>
+    <dct:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/UNKNOWN" />
+    <foaf:page>
+      <foaf:Document rdf:about="https://www.swisstopo.admin.ch/de/landesschwerenetz" />
+    </foaf:page>
+  </dcat:Dataset>
+</rdf:RDF>
+

--- a/ckanext/geocat/tests/test_dataset_metadata.py
+++ b/ckanext/geocat/tests/test_dataset_metadata.py
@@ -617,9 +617,7 @@ class TestLandesschwerenetzDcatMapping(unittest.TestCase):
         self.assertEqual(self.dataset["issued"], "2015-08-10T00:00:00")
 
     def test_accrual_periodicity(self):
-        self.assertIn(
-            "UNKNOWN", self.dataset["accrual_periodicity"]
-        )
+        self.assertIn("UNKNOWN", self.dataset["accrual_periodicity"])
 
     def test_five_resources(self):
         self.assertEqual(len(self.dataset["resources"]), 5)

--- a/ckanext/geocat/tests/test_dataset_metadata.py
+++ b/ckanext/geocat/tests/test_dataset_metadata.py
@@ -585,5 +585,92 @@ class TestCswMappingDatasetMetadata(unittest.TestCase):
         ]
 
 
+class TestLandesschwerenetzDcatMapping(unittest.TestCase):
+    """Smoke-tests for the Landesschwerenetz DCAT-AP-CH fixture."""
+
+    GEOCAT_ID = "95879cd4-e93d-4d4d-af57-4ec6731b9c97"
+    ORG_SLUG = "swisstopo"
+
+    def setUp(self):
+        mapper = _make_mapper(
+            organization_slug=self.ORG_SLUG,
+            valid_identifiers=[f"{self.GEOCAT_ID}@{self.ORG_SLUG}"],
+        )
+        xml = _load_xml("landesschwerenetz-dcat-ap-ch.xml")
+        self.dataset = mapper.get_metadata(xml, self.GEOCAT_ID)
+
+    # --- dataset-level ---
+
+    def test_identifier(self):
+        self.assertEqual(
+            self.dataset["identifier"],
+            f"{self.GEOCAT_ID}@{self.ORG_SLUG}",
+        )
+
+    def test_title_de(self):
+        self.assertEqual(self.dataset["title"]["de"], "Landesschwerenetz")
+
+    def test_title_fr(self):
+        self.assertEqual(self.dataset["title"]["fr"], "Réseau gravimétrique national")
+
+    def test_issued(self):
+        self.assertEqual(self.dataset["issued"], "2015-08-10T00:00:00")
+
+    def test_accrual_periodicity(self):
+        self.assertIn(
+            "UNKNOWN", self.dataset["accrual_periodicity"]
+        )
+
+    def test_five_resources(self):
+        self.assertEqual(len(self.dataset["resources"]), 5)
+
+    # --- distribution-level ---
+
+    def _resource_by_url(self, fragment):
+        for r in self.dataset["resources"]:
+            if fragment in r.get("url", ""):
+                return r
+        self.fail(f"No resource with url containing '{fragment}'")
+
+    def test_wms_resource_format(self):
+        wms = self._resource_by_url("wms.geo.admin.ch")
+        self.assertIn("WMS_SRVC", wms.get("format", ""))
+
+    def test_rest_resource_format(self):
+        rest = self._resource_by_url("api3.geo.admin.ch")
+        self.assertIn("REST", rest.get("format", ""))
+
+    def test_download_resource_has_download_url(self):
+        dl = self._resource_by_url("data.geo.admin.ch/browser")
+        self.assertTrue(dl.get("download_url"))
+
+    def test_map_preview_resource_url(self):
+        preview = self._resource_by_url("map.geo.admin.ch")
+        self.assertIn("map.geo.admin.ch", preview["url"])
+
+    def test_map_preview_title_prefixed_all_langs(self):
+        # DCAT path: missing language titles filled from description, then prefixed.
+        preview = self._resource_by_url("map.geo.admin.ch")
+        title = preview.get("title", {})
+        # All four CKAN langs must start with the prefix
+        for lang in ["de", "fr", "it", "en"]:
+            self.assertTrue(
+                title.get(lang, "").startswith("Map (Preview)"),
+                f"title[{lang}] = {title.get(lang)!r} does not start with 'Map (Preview)'",
+            )
+        # DE: sourced from dct:title
+        self.assertEqual("Map (Preview) Vorschau map.geo.admin.ch", title["de"])
+        # FR: sourced from dct:description (no dct:title in fr)
+        self.assertEqual("Map (Preview) Aperçu map.geo.admin.ch", title["fr"])
+        # IT: sourced from dct:description
+        self.assertEqual("Map (Preview) Previsione map.geo.admin.ch", title["it"])
+        # EN: "Preview" prefix stripped before adding "Map (Preview)"
+        self.assertEqual("Map (Preview) map.geo.admin.ch", title["en"])
+
+    def test_license_mapped(self):
+        for r in self.dataset["resources"]:
+            self.assertIn("terms_open", r.get("rights", ""))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/ckanext/geocat/utils/dcat_mapping.py
+++ b/ckanext/geocat/utils/dcat_mapping.py
@@ -144,8 +144,7 @@ def _apply_map_preview_title(title_dict, desc_dict, format_uri):
 
     # Step 1 – fill missing languages from description
     filled = {
-        lang: title_dict.get(lang) or desc_dict.get(lang, "")
-        for lang in CKAN_LANGS
+        lang: title_dict.get(lang) or desc_dict.get(lang, "") for lang in CKAN_LANGS
     }
 
     # Step 2 – prepend "Map (Preview)" prefix

--- a/ckanext/geocat/utils/dcat_mapping.py
+++ b/ckanext/geocat/utils/dcat_mapping.py
@@ -12,8 +12,15 @@ from lxml import etree
 
 from ckanext.geocat.utils.mapping_utils import MetadataFormatError
 from ckanext.geocat.utils.ogdch_map_utils import (
+    MAP_PROTOCOL_PREFIX,
+    _remove_duplicate_term_in_name,
     get_legal_basis_link,
     map_geocat_to_ogdch_identifier,
+)
+
+# EU file-type URI for map-preview distributions
+_MAP_PREVIEW_FORMAT_URI = (
+    "http://publications.europa.eu/resource/authority/file-type/MAP_PRVW"
 )
 
 log = logging.getLogger(__name__)
@@ -97,6 +104,61 @@ def _normalize_datetime(value):
     if not value:
         return ""
     return value.split("+")[0].split("Z")[0].strip()
+
+
+def _is_map_preview(title_dict, desc_dict, format_uri):
+    """
+    Detect a map-preview distribution in the DCAT-AP-CH path.
+
+    Signals (at least one must match):
+    - dct:format is the EU MAP_PRVW file-type URI
+    - DE title or description starts with "Vorschau" (German for preview)
+    - EN description starts with "Preview" (case-insensitive)
+    """
+    if format_uri == _MAP_PREVIEW_FORMAT_URI:
+        return True
+    de_title = title_dict.get("de", "")
+    de_desc = desc_dict.get("de", "")
+    en_desc = desc_dict.get("en", "")
+    if de_title.startswith("Vorschau") or de_desc.startswith("Vorschau"):
+        return True
+    if en_desc.lower().startswith("preview"):
+        return True
+    return False
+
+
+def _apply_map_preview_title(title_dict, desc_dict, format_uri):
+    """
+    For map-preview distributions arriving via the DCAT-AP-CH path:
+
+    1. Fill any language that has no title by using the description for that
+       language (the DCAT XML often only carries a DE title while supplying
+       descriptions in all four languages).
+    2. Prefix every language with "Map (Preview)", stripping a leading
+       "Preview" from the EN value to avoid "Map (Preview) Preview …".
+
+    For all other distributions the title_dict is returned unchanged.
+    """
+    if not _is_map_preview(title_dict, desc_dict, format_uri):
+        return title_dict
+
+    # Step 1 – fill missing languages from description
+    filled = {
+        lang: title_dict.get(lang) or desc_dict.get(lang, "")
+        for lang in CKAN_LANGS
+    }
+
+    # Step 2 – prepend "Map (Preview)" prefix
+    return {
+        "de": (MAP_PROTOCOL_PREFIX + " " + filled.get("de", "")).strip(),
+        "fr": (MAP_PROTOCOL_PREFIX + " " + filled.get("fr", "")).strip(),
+        "it": (MAP_PROTOCOL_PREFIX + " " + filled.get("it", "")).strip(),
+        "en": (
+            MAP_PROTOCOL_PREFIX
+            + " "
+            + _remove_duplicate_term_in_name(filled.get("en", ""), "Preview").strip()
+        ).strip(),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -363,13 +425,20 @@ class DcatMetadataMapping:
         )
 
         # multilingual description
-        resource["description"] = _filter_ckan_langs(
-            _xml_lang_dict(dist, "dct:description")
-        )
+        desc_dict = _filter_ckan_langs(_xml_lang_dict(dist, "dct:description"))
+        resource["description"] = desc_dict
 
-        # format (EU file-type URI, passed through as-is)
+        # format (EU file-type URI) — read early so _apply_map_preview_title can use it
         fmt_elems = dist.xpath("dct:format", namespaces=DCAT_NS)
         resource["format"] = _rdf_resource(fmt_elems[0]) if fmt_elems else ""
+
+        # Map-preview distributions: fill missing language titles from descriptions,
+        # then prefix all titles with "Map (Preview)".
+        resource["title"] = _apply_map_preview_title(
+            resource["title"], desc_dict, resource["format"]
+        )
+
+        # format already set above
 
         # media type (IANA URI, passed through as-is)
         mt_elems = dist.xpath("dcat:mediaType", namespaces=DCAT_NS)

--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -260,7 +260,9 @@ def _map_geocat_resource_name_to_title(normed_protocol, name):
 def _remove_duplicate_term_in_name(name, term):
     if not name:
         return ""
-    return name.lstrip(term)
+    if name.startswith(term):
+        return name[len(term):]
+    return name
 
 
 def map_service(geocat_service, issued, modified, description, rights, license):

--- a/ckanext/geocat/utils/ogdch_map_utils.py
+++ b/ckanext/geocat/utils/ogdch_map_utils.py
@@ -261,7 +261,7 @@ def _remove_duplicate_term_in_name(name, term):
     if not name:
         return ""
     if name.startswith(term):
-        return name[len(term):]
+        return name[len(term) :]
     return name
 
 


### PR DESCRIPTION
- Fix _remove_duplicate_term_in_name: use startswith() instead of lstrip() to avoid stripping individual characters from resource names
- Add _is_map_preview() detection in dcat_mapping (format URI, DE title/desc starting with 'Vorschau', EN desc starting with 'preview')
- Add _apply_map_preview_title() to prefix DCAT-AP-CH map-preview distributions with 'Map (Preview)', filling missing language titles from descriptions
- Add TestLandesschwerenetzDcatMapping test class with fixture